### PR TITLE
chore: allow latest healthchek lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "require": {
         "php": ">=7.2.0",
         "ext-json": "*",
-        "oat-sa/lib-health-check": "^1.1",
-        "psr/log": "^1.1",
+        "oat-sa/lib-health-check": "^1.1 || ^2",
+        "psr/log": "^1.1 || ^2 || ^3",
         "symfony/console": "^4.4 || ^5.0 || ^6.0",
         "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
         "symfony/yaml": "^4.4 || ^5.0 || ^6.0"


### PR DESCRIPTION
# Add support for third-party libraries 


## Description 
This PR extends the possibility of using the  latest version for `lib-health-check` 