### PR TITLE
fix: replace hardcoded SONAR_HOST_URL with secret reference

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -25,7 +25,7 @@ jobs:
         uses: sonarsource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: 'https://sonarqube.taotesting.info/sonarqube/'
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       # Job will fail when the Quality Gate is red
       - name: Sonarqube quality gate check


### PR DESCRIPTION
## Summary

Replaces the hardcoded SonarQube URL in `sonar.yml` with a secret reference:

```yaml
# Before
SONAR_HOST_URL: 'https://sonarqube.taotesting.info/sonarqube/'

# After
SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
```

This avoids hardcoded URLs in CI workflow files and uses the org/repo secret instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality analysis configuration to use the configured SonarQube server URL securely.
  * SonarQube quality gate status reporting remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->