### PR TITLE
TR-6874: Support Symfony 7.4

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php-version: [ '8.2', '8.3', '8.4' ]
         coverage: [ false ]
         include:
-          - php-version: '8.4'
+          - php-version: '8.5'
             coverage: true
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+Unreleased
+----------
+
+* Breaking: require Symfony 6 or 7 (`^6.0 || ^7.0`)
+* Breaking: require PHP >= 8.2
+* Use colinodell/psr-testlogger in functional tests (psr/log 3 compatibility)
+
 2.1.0
 -----
 

--- a/Tests/Resources/Kernel/config.yaml
+++ b/Tests/Resources/Kernel/config.yaml
@@ -4,4 +4,4 @@ framework:
 
 services:
     logger:
-        class: Psr\Log\Test\TestLogger
+        class: ColinODell\PsrTestLogger\TestLogger

--- a/composer.json
+++ b/composer.json
@@ -5,18 +5,19 @@
     "type": "symfony-bundle",
     "license": "LGPL-2.1-only",
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=8.2.0",
         "ext-json": "*",
-        "oat-sa/lib-health-check": "^1.1 || ^2",
+        "oat-sa/lib-health-check": "^2.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
-        "symfony/console": "^4.4 || ^5.0 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.0 || ^6.0"
+        "symfony/console": "^6.0 || ^7.0",
+        "symfony/framework-bundle": "^6.0 || ^7.0",
+        "symfony/yaml": "^6.0 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "8.5.14 || ^9.5",
+        "phpunit/phpunit": "^9.5",
         "php-coveralls/php-coveralls": "^2.4",
-        "symfony/browser-kit": "^4.4 || ^5.0"
+        "symfony/browser-kit": "^6.0 || ^7.0",
+        "colinodell/psr-testlogger": "^1.3"
     },
     "autoload": {
         "psr-4": { "OAT\\Bundle\\HealthCheckBundle\\": "" },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
@@ -18,13 +18,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
# Support Symfony 7.4 [TR-6874](https://oat-sa.atlassian.net/browse/TR-6874)

Raise bundle Symfony constraints to `^6.0 || ^7.0` (console, framework-bundle, yaml, browser-kit), require PHP `>=8.2`, and keep `oat-sa/lib-health-check` at `^2.0`. CI matrix is now PHP 8.2–8.5. Functional tests switch from `Psr\Log\Test\TestLogger` to `colinodell/psr-testlogger` for `psr/log` 3.

## Related PRs

- https://github.com/oat-sa/lib-health-check/pull/17
- https://github.com/oat-sa/bundle-health-check/pull/22
- https://github.com/oat-sa/bundle-grader-messenger-bridge/pull/29
- https://github.com/oat-sa/environment-management/pull/1461
- https://github.com/oat-sa/tao-timers-client/pull/16
- https://github.com/oat-sa/lib-qti-item-json-compilation/pull/87

## How to test

1. Checkout `feat/TR-6874/symfony-7` in `tao-deliver-be` (testrunner).

[TR-6874]: https://oat-sa.atlassian.net/browse/TR-6874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ